### PR TITLE
docs: fix Claude Code plugin install paths

### DIFF
--- a/.claude/plugins/math-to-manim/README.md
+++ b/.claude/plugins/math-to-manim/README.md
@@ -15,21 +15,13 @@ This Claude Code skill provides a complete workflow for generating mathematical 
 
 ## Installation
 
-### Option 1: Install from GitHub
-
-```bash
-# Using skills.sh (coming soon)
-npx skills add HarleyCoops/Math-To-Manim/skill
-```
-
-### Option 2: Local Installation
-
 ```bash
 # Clone the repository
 git clone https://github.com/HarleyCoops/Math-To-Manim.git
+cd Math-To-Manim
 
-# Run Claude Code with the plugin
-claude --plugin-dir ./Math-To-Manim/skill
+# Run Claude Code with the bundled plugin
+claude --plugin-dir ./.claude/plugins/math-to-manim
 ```
 
 ## Usage
@@ -67,7 +59,7 @@ This builds pedagogically sound animations that flow naturally from foundation c
 ## Directory Structure
 
 ```
-skill/
+.claude/plugins/math-to-manim/
 ├── .claude-plugin/
 │   └── plugin.json          # Plugin manifest
 ├── skills/

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@
 
 ## Claude Code Learns Manim
 
-**Use Math-To-Manim directly in Claude Code** — no setup required. Just install the skill and start creating animations with natural language.
+**Use Math-To-Manim directly in Claude Code** — no setup required. Just load the bundled plugin and start creating animations with natural language.
 
 ### Quick Install
 
 ```bash
-# Clone and run with the skill
+# Clone and run with the bundled plugin
 git clone https://github.com/HarleyCoops/Math-To-Manim.git
-claude --plugin-dir ./Math-To-Manim/skill
+claude --plugin-dir ./Math-To-Manim/.claude/plugins/math-to-manim
 ```
 
 ### What You Can Do
@@ -63,7 +63,7 @@ No training data. No examples needed. Pure LLM reasoning builds pedagogically so
 <summary><b>Skill Directory Structure</b></summary>
 
 ```
-skill/
+.claude/plugins/math-to-manim/
 ├── .claude-plugin/plugin.json
 └── skills/math-to-manim/
     ├── SKILL.md                       # Core workflow definition


### PR DESCRIPTION
## Summary
- update the root README to point Claude Code users at the bundled plugin path instead of the removed `./Math-To-Manim/skill` directory
- update the plugin README to use the current `.claude/plugins/math-to-manim` location and matching directory structure
- remove the stale install snippet that referenced the old `npx skills add HarleyCoops/Math-To-Manim/skill` path

## Test plan
- [x] Run `python -m pytest` *(currently fails during test collection because the repository is missing existing dependencies/modules such as `google.genai`, `google.adk`, and `KimiK2Thinking`)*
- [x] Verify the changed README snippets now reference `.claude/plugins/math-to-manim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)