### PR TITLE
docs: focus README on pipeline workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@
 
 # Math to Manim
 
-### Ask a question → Get A Movie
+### Ask a question -> reverse reasoning -> Manim movie
 
 [![Python 3.10+](https://img.shields.io/badge/Python-3.10%2B-3b82f6)](https://www.python.org/)
 [![Manim CE](https://img.shields.io/badge/Manim-CE-f59e0b)](https://www.manim.community/)
 [![OpenAI Agents SDK](https://img.shields.io/badge/OpenAI-Agents%20SDK-111827)](https://openai.github.io/openai-agents-python/)
-[![Hermes assisted](https://img.shields.io/badge/Hermes-learns%20Manim-8b5cf6)](#hermes-learns-manim)
+[![Hermes assisted](https://img.shields.io/badge/Hermes-agent%20assisted-8b5cf6)](#hermes-agent)
 [![License: MIT](https://img.shields.io/badge/License-MIT-22c55e)](LICENSE)
 
-[Motion showcase](docs/showcase/README.md) · [Roadmap](docs/ROADMAP.md) · [Deployment roadmap](docs/DEPLOYMENT_ROADMAP.md) · [Architecture](docs/ARCHITECTURE.md) · [Launch plan](docs/HERMES_LEARNS_MANIM.md) · [Agent guide](AGENTS.md)
+[Motion showcase](docs/showcase/README.md) · [Architecture](docs/ARCHITECTURE.md) · [Roadmap](docs/ROADMAP.md) · [Agent guide](AGENTS.md)
 
 <br />
 
@@ -47,94 +47,19 @@
   <a href="docs/showcase/README.md"><img src="docs/showcase/assets/whiskering-exchange.gif" alt="Whiskering exchange animation" width="24%" /></a>
 </p>
 
-**Math-To-Manim helps teachers, tutors, parents, and guardians turn questions into visual explanations they can inspect, adjust, and reuse.**
+**Math-To-Manim turns short prompts into reverse-reasoned lesson plans, typed pipeline artifacts, generated Manim code, and reusable visual explanations.**
 
 [**Browse the local GIF gallery →**](docs/showcase/README.md)
 
 <br />
 
-<img src="docs/assets/hermes-learns-manim.jpg" alt="Hermes Learns Manim banner with mathematical formulas" width="760" />
+<img src="docs/assets/reverse-reasoning-pipeline.svg" alt="Reverse reasoning pipeline diagram showing the actual Math-To-Manim stage agents, artifacts, validation gate, render path, review, package, and manifest" width="100%" />
 
 <br />
 
-## Hermes learns Manim
-
-This repo is also a live **Hermes Agent workspace**. Hermes is not imported by Math-To-Manim and is not a runtime dependency; it is the contributor/operator layer that uses the repo the way a developer would: read files, search code, patch docs and code, run terminal checks, inspect generated artifacts, review media with vision, delegate larger work, track todos, and preserve useful context through skills and memory.
-
-| Hermes-native capability | How it is used in Math-To-Manim |
-| --- | --- |
-| File + search tools | Read `README.md`, `AGENTS.md`, `pyproject.toml`, schemas, tests, docs, and generated run artifacts before making claims. |
-| Patch tool | Make surgical edits to docs, schemas, tests, pipeline code, and launch copy while preserving repo style and typed contracts. |
-| Terminal tool | Run `pytest`, CLI help, deterministic smoke generations, Codex checks, Manim, FFmpeg, link validators, git, and GitHub verification. |
-| Vision/media review | Inspect screenshots, contact sheets, frames, and GIFs so showcase media is judged visually, not trusted because filenames exist. |
-| Delegation + todos | Split larger work across focused agents, track acceptance criteria, and keep implementation/review/checklist state explicit. |
-| Session search + memory | Recover prior repo decisions and preserve stable conventions without storing secrets or temporary run noise. |
-| Skills | Load procedures such as `agents-md`, `codebase-inspection`, `manim-video`, `systematic-debugging`, `writing-plans`, `test-driven-development`, and `subagent-driven-development`. |
-
-The Math-To-Manim side gives Hermes concrete things to operate: the `math-to-manim` CLI, deterministic helpers in `math_to_manim/tools/`, typed stages in `math_to_manim/agents/` and `math_to_manim/pipeline/`, schemas in `math_to_manim/schemas/`, render/review helpers, and reproducible `runs/<run_id>/` bundles containing JSON contracts, `generated_scene.py`, validation/render/review reports, contact sheets, frames, and `manifest.json`.
-
-Start a repo-aware Hermes session:
-
-```bash
-# Install/configure Hermes if needed.
-curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
-hermes setup
-hermes doctor
-
-# From the repo root, preload skills for this repo.
-hermes --skills agents-md,manim-video,codebase-inspection,systematic-debugging
-```
-
-See [`AGENTS.md`](AGENTS.md) for the full operating contract and [`docs/HERMES_LEARNS_MANIM.md`](docs/HERMES_LEARNS_MANIM.md) for the launch/thread plan and new animation slate.
+<em>Code-grounded workflow: every run stays inspectable from prompt to artifacts to render.</em>
 
 </div>
-
----
-
-## Start here: Hermes + Math-To-Manim setup
-
-This repo is meant to be operated by **Hermes Agent** while Math-To-Manim provides the visual explanation pipeline. The split is intentional:
-
-- **Hermes** is the repo operator: skills, file/search/patch tools, terminal checks, vision review, todos, delegation, memory, and GitHub verification.
-- **Math-To-Manim** is the Python package: typed curriculum/storyboard artifacts, Manim code generation, validation, render/review bundles, and showcase assets.
-
-Fastest path for a new checkout:
-
-```bash
-git clone https://github.com/HarleyCoops/Math-To-Manim.git
-cd Math-To-Manim
-
-# 1. Install and verify the Python package.
-python3 -m venv .venv
-source .venv/bin/activate
-python -m pip install -U pip
-python -m pip install -e ".[dev]"
-python -m pytest
-
-# 2. Install and verify Hermes.
-curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
-hermes setup
-hermes doctor
-hermes tools list --summary
-hermes skills list
-
-# 3. Register this repo's local Math-To-Manim skill.
-hermes config set skills.external_dirs "$(pwd)/hermes/skills"
-hermes skills list --source local
-
-# 4. Start Hermes with the repo skill plus the procedural skills that matter here.
-hermes --skills hermes-learns-manim,agents-md,codebase-inspection,manim-video,systematic-debugging
-```
-
-Once Hermes is inside this repo, the expected workflow is concrete: read `AGENTS.md`, inspect `pyproject.toml` and CLI help, run deterministic smoke generations, open the `runs/<run_id>/` artifact bundle, visually inspect frames/GIFs when media changes, then commit/push only verified docs/code/assets.
-
-See [How Hermes uses this repo](#hermes-learns-manim) for the detailed tool map.
-
-### Where is the old Claude skill?
-
-The old Claude Code instructions that referenced `./skill` are historical. This rewrite does not keep a root `skill/` directory, and `claude --plugin-dir ./skill ...` is not the recommended path for the current repo.
-
-Repo-local Hermes skills live under [`hermes/skills/`](hermes/skills/). Register that parent directory with Hermes as shown above so individual skills (for example [`hermes-learns-manim/SKILL.md`](hermes/skills/hermes-learns-manim/SKILL.md)) are discoverable by name, then run Hermes with `--skills hermes-learns-manim,...`. The `hermes-learns-manim` skill is contributor/operator guidance around the M2M2 CLI, Codex-backed codegen option, deterministic smoke runs, and artifact review; it is not imported by the `math_to_manim` Python package.
 
 ---
 
@@ -146,36 +71,38 @@ The input can be short, but the product is the explanation: what the learner nee
 
 Math-To-Manim proves that calculus, topology, chaos, spacetime, stochastic finance, and ML concepts can become useful mathematical motion when agents plan the explanation before they write code.
 
-This repo turns that idea into a durable teaching pipeline:
+This repo turns that idea into a durable agent pipeline:
 
 - a prerequisite-story pipeline inspired by the original reverse knowledge tree;
 - typed Pydantic artifacts between every stage;
 - OpenAI Agents SDK-compatible adapters for planning and generation;
 - optional Codex CLI-backed codegen for subscription-authenticated iteration;
 - a reproducible `runs/<run_id>/` bundle for every generation;
-- static validation, render metadata, review artifacts, and manifests that are easy to inspect in CI, by Hermes, or by another agent.
+- static validation, render metadata, review artifacts, and manifests that are easy to inspect in CI or by another agent.
 
 The design principle is simple: **story before symbols, geometry before algebra, artifacts before side effects.**
 
 ---
 
-## What makes this different
+## Reverse reasoning pipeline
 
-A normal text-to-code demo jumps from a request straight to Python. Math to Manim takes the long way on purpose:
+A normal text-to-code demo jumps from request to Python. Math-To-Manim takes the long way on purpose: it reasons backward from the final concept to the prerequisites, then walks forward through a teachable visual sequence.
 
-```text
-question
-  → intent: what is the learner really asking?
-  → prerequisite graph: what must be understood first?
-  → curriculum: what order makes the idea click?
-  → math packet: which definitions/equations matter?
-  → storyboard: what should move on screen?
-  → scene spec: what Manim objects and beats are needed?
-  → generated_scene.py
-  → static validation / repair
-  → Manim render
-  → review artifacts / showcase GIF
-```
+The code path is explicit in [`math_to_manim/pipeline/runner.py`](math_to_manim/pipeline/runner.py). `AnimationPipeline.generate()` runs a fixed stage chain: `IntentAgent`, `PrerequisiteGraphAgent`, `CurriculumAgent`, `MathAgent`, `StoryboardAgent`, `SceneSpecAgent`, `ManimCodeAgent`, `StaticReviewAgent`, `RenderAgent`, `VideoReviewAgent`, and `PublisherAgent`.
+
+| Stage | Why it exists | Artifact |
+| --- | --- | --- |
+| Intent | Clarify what the learner is really asking. | `intent.json` |
+| Reverse prerequisites | Build the knowledge graph needed before the target idea. | `knowledge_graph.json` |
+| Curriculum | Turn the graph into a teachable order. | `curriculum.json` |
+| Math packet | Select definitions, equations, assumptions, and examples. | `math_packet.json` |
+| Storyboard | Decide the screen beats before code exists. | `storyboard.json` |
+| Scene spec | Compile the visual plan into Manim objects, animations, timing, and camera notes. | `scene_spec.json` |
+| Code, validation, render, review | Generate runnable Manim, gate it with static checks, render when allowed, and package the evidence. | `generated_scene.py`, reports, manifest |
+
+<p align="center">
+  <img src="docs/assets/render-repair-loop.svg" alt="Render validation and bounded repair loop diagram showing static review, render skip, Manim subprocess, repair from frozen scene spec, video review, and publisher package" width="100%" />
+</p>
 
 That gives every run a memory: JSON contracts, generated code, render results, review notes, and a manifest. The output is not just a video; it is an inspectable path from **question** to **understanding** to **animation**.
 
@@ -323,6 +250,16 @@ math_to_manim/
   rendering/   # Manim and FFmpeg wrappers
   review/      # static and visual review scoring
 ```
+
+---
+
+## Hermes Agent
+
+Hermes is the contributor/operator agent around this repository. It is not imported by Math-To-Manim and is not a runtime dependency; it uses the repo the way a developer would: read files, search code, patch docs and code, run terminal checks, inspect generated artifacts, review frames or GIFs, track todos, delegate larger work, and preserve stable context through skills.
+
+That makes Hermes useful for maintaining the reverse-reasoning pipeline without becoming part of it. A Hermes session can inspect `AGENTS.md`, `pyproject.toml`, schemas, tests, and `runs/<run_id>/` bundles; run `pytest`, CLI smoke commands, Manim, FFmpeg, and git checks; then verify that docs, code, and showcase media still match the artifact contracts.
+
+Repo-local Hermes skills live under [`hermes/skills/`](hermes/skills/). The old Claude `./skill` path is historical; current contributor guidance is in [`AGENTS.md`](AGENTS.md), with launch notes in [`docs/HERMES_LEARNS_MANIM.md`](docs/HERMES_LEARNS_MANIM.md).
 
 ---
 

--- a/docs/assets/render-repair-loop.svg
+++ b/docs/assets/render-repair-loop.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="760" viewBox="0 0 1600 760" role="img" aria-labelledby="title desc">
+  <title id="title">Math-To-Manim validation and render repair loop</title>
+  <desc id="desc">A diagram of the static validation gate and bounded render repair loop in AnimationPipeline.generate.</desc>
+  <defs>
+    <style>
+      .bg { fill: #f8fafc; }
+      .title { fill: #101828; font: 700 42px Arial, sans-serif; }
+      .subtitle { fill: #475467; font: 400 22px Arial, sans-serif; }
+      .box { fill: #ffffff; stroke: #cbd5e1; stroke-width: 2; rx: 16; }
+      .code { stroke: #d97706; }
+      .render { stroke: #059669; }
+      .fail { stroke: #dc2626; }
+      .gate { fill: #fff7ed; stroke: #f97316; stroke-width: 2; }
+      .agent { fill: #111827; font: 700 20px Arial, sans-serif; }
+      .artifact { fill: #475467; font: 400 17px Arial, sans-serif; }
+      .small { fill: #667085; font: 400 15px Arial, sans-serif; }
+      .arrow { stroke: #64748b; stroke-width: 3; fill: none; marker-end: url(#arrow); }
+      .repair { stroke: #dc2626; stroke-width: 3; fill: none; marker-end: url(#arrow-red); stroke-dasharray: 9 7; }
+      .band { fill: #ffffff; stroke: #e2e8f0; stroke-width: 1.5; rx: 20; }
+      .note { fill: #f1f5f9; stroke: #cbd5e1; stroke-width: 1.5; rx: 14; }
+      .mono { fill: #334155; font: 600 15px "Courier New", monospace; }
+    </style>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
+      <path d="M2,2 L10,6 L2,10 Z" fill="#64748b" />
+    </marker>
+    <marker id="arrow-red" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
+      <path d="M2,2 L10,6 L2,10 Z" fill="#dc2626" />
+    </marker>
+  </defs>
+
+  <rect class="bg" width="1600" height="760" />
+  <text class="title" x="70" y="78">Validation and render repair loop</text>
+  <text class="subtitle" x="70" y="116">Rendering is gated by static review. Failed renders repair only generated Manim code from the frozen scene spec.</text>
+
+  <rect class="band" x="60" y="166" width="1480" height="438" />
+
+  <rect class="box code" x="120" y="282" width="240" height="104" />
+  <text class="agent" x="146" y="322">ManimCodeAgent</text>
+  <text class="artifact" x="146" y="350">generated_code.json</text>
+  <text class="artifact" x="146" y="374">generated_scene.py</text>
+
+  <rect class="box code" x="450" y="282" width="240" height="104" />
+  <text class="agent" x="476" y="322">StaticReviewAgent</text>
+  <text class="artifact" x="476" y="350">AST checks</text>
+  <text class="artifact" x="476" y="374">validation_report.json</text>
+
+  <polygon class="gate" points="850,262 958,334 850,406 742,334" />
+  <text class="agent" x="803" y="323">passes static</text>
+  <text class="agent" x="827" y="348">review?</text>
+
+  <rect class="box fail" x="1052" y="228" width="290" height="94" />
+  <text class="agent" x="1080" y="267">No render call</text>
+  <text class="artifact" x="1080" y="294">RenderResult skipped</text>
+
+  <rect class="box render" x="1052" y="396" width="290" height="94" />
+  <text class="agent" x="1080" y="435">RenderAgent</text>
+  <text class="artifact" x="1080" y="462">subprocess Manim</text>
+
+  <rect class="box render" x="636" y="500" width="300" height="82" />
+  <text class="agent" x="664" y="534">VideoReviewAgent</text>
+  <text class="artifact" x="664" y="560">probe, frames, contact sheet</text>
+
+  <rect class="box render" x="1016" y="500" width="300" height="82" />
+  <text class="agent" x="1044" y="534">PublisherAgent</text>
+  <text class="artifact" x="1044" y="560">package + manifest</text>
+
+  <rect class="box fail" x="122" y="500" width="338" height="82" />
+  <text class="agent" x="150" y="534">Repair path</text>
+  <text class="artifact" x="150" y="560">repair(scene_spec, generated, failure)</text>
+
+  <path class="arrow" d="M360 334 H450" />
+  <path class="arrow" d="M690 334 H742" />
+  <path class="arrow" d="M958 304 H1052" />
+  <text class="small" x="992" y="288">no</text>
+  <path class="arrow" d="M958 364 H1006 V443 H1052" />
+  <text class="small" x="992" y="386">yes</text>
+  <path class="arrow" d="M1197 490 V541 H936" />
+  <path class="arrow" d="M936 541 H1016" />
+
+  <path class="repair" d="M1052 443 C900 664 520 664 291 582" />
+  <path class="repair" d="M291 500 C306 456 220 442 240 386" />
+  <text class="small" x="504" y="664">if render failed, deterministic is false, and repair_attempt &lt; max_render_repairs</text>
+
+  <rect class="note" x="82" y="638" width="1416" height="62" />
+  <text class="mono" x="108" y="674">Frozen upstream contract:</text>
+  <text class="small" x="330" y="674">the repair loop reuses the same scene_spec plus recorded stderr/stdout. It does not rerun intent, graph, curriculum, math, or storyboard planning.</text>
+</svg>

--- a/docs/assets/reverse-reasoning-pipeline.svg
+++ b/docs/assets/reverse-reasoning-pipeline.svg
@@ -1,0 +1,139 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="980" viewBox="0 0 1600 980" role="img" aria-labelledby="title desc">
+  <title id="title">Math-To-Manim reverse reasoning pipeline</title>
+  <desc id="desc">A diagram of AnimationPipeline.generate showing the ordered stage agents, emitted artifacts, validation gate, render path, review, and final package.</desc>
+  <defs>
+    <style>
+      .bg { fill: #f8fafc; }
+      .title { fill: #101828; font: 700 42px Arial, sans-serif; }
+      .subtitle { fill: #475467; font: 400 22px Arial, sans-serif; }
+      .lane-title { fill: #344054; font: 700 18px Arial, sans-serif; letter-spacing: .08em; }
+      .box { fill: #ffffff; stroke: #cbd5e1; stroke-width: 2; rx: 14; }
+      .box-planning { stroke: #2563eb; }
+      .box-code { stroke: #d97706; }
+      .box-render { stroke: #059669; }
+      .agent { fill: #111827; font: 700 17px Arial, sans-serif; }
+      .artifact { fill: #475467; font: 400 15px Arial, sans-serif; }
+      .small { fill: #667085; font: 400 14px Arial, sans-serif; }
+      .gate { fill: #fff7ed; stroke: #f97316; stroke-width: 2; }
+      .skip { fill: #f1f5f9; stroke: #94a3b8; stroke-width: 2; rx: 14; }
+      .arrow { stroke: #64748b; stroke-width: 3; fill: none; marker-end: url(#arrow); }
+      .arrow-soft { stroke: #94a3b8; stroke-width: 2.5; fill: none; marker-end: url(#arrow-soft); }
+      .band { fill: #eff6ff; stroke: #bfdbfe; stroke-width: 1.5; rx: 18; }
+      .band-code { fill: #fff7ed; stroke: #fed7aa; }
+      .band-render { fill: #ecfdf5; stroke: #bbf7d0; }
+      .note { fill: #ffffff; stroke: #e2e8f0; stroke-width: 1.5; rx: 14; }
+      .code { fill: #334155; font: 600 15px "Courier New", monospace; }
+    </style>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
+      <path d="M2,2 L10,6 L2,10 Z" fill="#64748b" />
+    </marker>
+    <marker id="arrow-soft" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
+      <path d="M2,2 L10,6 L2,10 Z" fill="#94a3b8" />
+    </marker>
+  </defs>
+
+  <rect class="bg" width="1600" height="980" />
+
+  <text class="title" x="70" y="74">Reverse reasoning pipeline</text>
+  <text class="subtitle" x="70" y="112">Actual ordered path in math_to_manim/pipeline/runner.py: story first, typed artifacts next, Manim only after validation.</text>
+
+  <rect class="band" x="52" y="150" width="1496" height="306" />
+  <text class="lane-title" x="80" y="184">PLANNING ARTIFACTS</text>
+
+  <rect class="box box-planning" x="80" y="220" width="176" height="104" />
+  <text class="agent" x="104" y="258">UserRequest</text>
+  <text class="artifact" x="104" y="286">request.json</text>
+
+  <rect class="box box-planning" x="305" y="220" width="176" height="104" />
+  <text class="agent" x="329" y="258">IntentAgent</text>
+  <text class="artifact" x="329" y="286">intent.json</text>
+
+  <rect class="box box-planning" x="530" y="220" width="206" height="104" />
+  <text class="agent" x="554" y="258">PrerequisiteGraph</text>
+  <text class="agent" x="554" y="281">Agent</text>
+  <text class="artifact" x="554" y="307">knowledge_graph.json</text>
+
+  <rect class="box box-planning" x="785" y="220" width="176" height="104" />
+  <text class="agent" x="809" y="258">CurriculumAgent</text>
+  <text class="artifact" x="809" y="286">curriculum.json</text>
+
+  <rect class="box box-planning" x="1010" y="220" width="176" height="104" />
+  <text class="agent" x="1034" y="258">MathAgent</text>
+  <text class="artifact" x="1034" y="286">math_packet.json</text>
+
+  <rect class="box box-planning" x="1235" y="220" width="176" height="104" />
+  <text class="agent" x="1259" y="258">StoryboardAgent</text>
+  <text class="artifact" x="1259" y="286">storyboard.json</text>
+
+  <rect class="box box-planning" x="655" y="352" width="250" height="80" />
+  <text class="agent" x="679" y="384">SceneSpecAgent</text>
+  <text class="artifact" x="679" y="410">scene_spec.json</text>
+
+  <path class="arrow" d="M256 272 H305" />
+  <path class="arrow" d="M481 272 H530" />
+  <path class="arrow" d="M736 272 H785" />
+  <path class="arrow" d="M961 272 H1010" />
+  <path class="arrow" d="M1186 272 H1235" />
+  <path class="arrow" d="M1323 324 V392 H905" />
+
+  <rect class="band band-code" x="52" y="488" width="1496" height="206" />
+  <text class="lane-title" x="80" y="522">CODE GENERATION AND STATIC GATE</text>
+
+  <rect class="box box-code" x="170" y="570" width="220" height="94" />
+  <text class="agent" x="194" y="607">ManimCodeAgent</text>
+  <text class="artifact" x="194" y="633">generated_code.json</text>
+  <text class="artifact" x="194" y="654">generated_scene.py</text>
+
+  <rect class="box box-code" x="480" y="570" width="220" height="94" />
+  <text class="agent" x="504" y="607">StaticReviewAgent</text>
+  <text class="artifact" x="504" y="633">validation_report.json</text>
+
+  <polygon class="gate" points="870,556 960,617 870,678 780,617" />
+  <text class="agent" x="832" y="606">validation</text>
+  <text class="agent" x="834" y="628">successful?</text>
+
+  <rect class="skip" x="1060" y="570" width="260" height="94" />
+  <text class="agent" x="1084" y="607">Render skipped</text>
+  <text class="artifact" x="1084" y="633">RenderResult</text>
+  <text class="small" x="1084" y="654">metadata.skipped = true</text>
+
+  <path class="arrow" d="M780 392 V532 H280 V570" />
+  <path class="arrow" d="M390 617 H480" />
+  <path class="arrow" d="M700 617 H780" />
+  <path class="arrow" d="M960 617 H1060" />
+  <text class="small" x="990" y="596">no</text>
+
+  <rect class="band band-render" x="52" y="726" width="1496" height="176" />
+  <text class="lane-title" x="80" y="760">RENDER, REVIEW, PACKAGE</text>
+
+  <rect class="box box-render" x="210" y="802" width="205" height="78" />
+  <text class="agent" x="234" y="834">RenderAgent</text>
+  <text class="artifact" x="234" y="858">render_result.json</text>
+
+  <rect class="box box-render" x="535" y="802" width="220" height="78" />
+  <text class="agent" x="559" y="834">VideoReviewAgent</text>
+  <text class="artifact" x="559" y="858">review_report.json</text>
+
+  <rect class="box box-render" x="875" y="802" width="220" height="78" />
+  <text class="agent" x="899" y="834">PublisherAgent</text>
+  <text class="artifact" x="899" y="858">animation_package.json</text>
+
+  <rect class="box box-render" x="1215" y="802" width="205" height="78" />
+  <text class="agent" x="1239" y="834">Manifest</text>
+  <text class="artifact" x="1239" y="858">manifest.json</text>
+
+  <path class="arrow" d="M870 678 V704 H312 V802" />
+  <text class="small" x="810" y="704">yes</text>
+  <path class="arrow" d="M415 841 H535" />
+  <path class="arrow" d="M755 841 H875" />
+  <path class="arrow" d="M1095 841 H1215" />
+
+  <rect class="note" x="1048" y="362" width="360" height="86" />
+  <text class="code" x="1072" y="394">deterministic mode</text>
+  <text class="small" x="1072" y="420">Offline scaffolded artifacts keep CLI</text>
+  <text class="small" x="1072" y="442">smoke tests reproducible.</text>
+
+  <rect class="note" x="1092" y="704" width="360" height="78" />
+  <text class="code" x="1116" y="736">artifact contract</text>
+  <text class="small" x="1116" y="762">The run directory mirrors control flow.</text>
+</svg>


### PR DESCRIPTION
Replace top-heavy Hermes README framing with code-grounded reverse-reasoning and repair-loop diagrams.