### PR TITLE
docs: add 3D circle area showcase GIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,21 @@
 <br />
 
 <p align="center">
+  <a href="docs/showcase/README.md"><img src="docs/showcase/assets/circle-area-3d-unwrapped.gif" alt="3D circle area derivation from annuli to unwrapped triangle" width="24%" /></a>
   <a href="docs/showcase/README.md"><img src="docs/showcase/assets/rhombicosidodecahedron.gif" alt="Rhombicosidodecahedron animation" width="24%" /></a>
   <a href="docs/showcase/README.md"><img src="docs/showcase/assets/cosmic-gravity-3d.gif" alt="Cosmic gravity 3D animation" width="24%" /></a>
   <a href="docs/showcase/README.md"><img src="docs/showcase/assets/continuous-geometric-picture.gif" alt="Full GRPO semantic manifold animation" width="24%" /></a>
-  <a href="docs/showcase/README.md"><img src="docs/showcase/assets/derivative-visualization.gif" alt="Derivative visualization animation" width="24%" /></a>
 </p>
 
 <p align="center">
+  <a href="docs/showcase/README.md"><img src="docs/showcase/assets/derivative-visualization.gif" alt="Derivative visualization animation" width="24%" /></a>
   <a href="docs/showcase/README.md"><img src="docs/showcase/assets/prolip-scene.gif" alt="ProLIP animation" width="24%" /></a>
   <a href="docs/showcase/README.md"><img src="docs/showcase/assets/lorenz-attractor.gif" alt="Lorenz attractor animation" width="24%" /></a>
   <a href="docs/showcase/README.md"><img src="docs/showcase/assets/hopf-fibration.gif" alt="Hopf fibration animation" width="24%" /></a>
-  <a href="docs/showcase/README.md"><img src="docs/showcase/assets/fourier-epicycles.gif" alt="Fourier epicycles animation" width="24%" /></a>
 </p>
 
 <p align="center">
+  <a href="docs/showcase/README.md"><img src="docs/showcase/assets/fourier-epicycles.gif" alt="Fourier epicycles animation" width="24%" /></a>
   <a href="docs/showcase/README.md"><img src="docs/showcase/assets/teaching-hopf.gif" alt="Teaching Hopf animation" width="24%" /></a>
   <a href="docs/showcase/README.md"><img src="docs/showcase/assets/brownian-finance.gif" alt="Brownian finance animation" width="24%" /></a>
   <a href="docs/showcase/README.md"><img src="docs/showcase/assets/radius-of-convergence.gif" alt="Radius of convergence animation" width="24%" /></a>

--- a/docs/showcase/README.md
+++ b/docs/showcase/README.md
@@ -35,24 +35,30 @@ They are not just decoration. They define the bar M2M2 should eventually hit:
 
 <table>
 <tr>
+<td width="33%"><img src="assets/circle-area-3d-unwrapped.gif" alt="3D circle area derivation" /></td>
 <td width="33%"><img src="assets/rhombicosidodecahedron.gif" alt="Rhombicosidodecahedron" /></td>
 <td width="33%"><img src="assets/cosmic-gravity-3d.gif" alt="Cosmic gravity 3D" /></td>
-<td width="33%"><img src="assets/derivatives-as-slopes.gif" alt="Derivatives as slopes" /></td>
 </tr>
 <tr>
+<td><b>Circle area 3D</b><br />Nested annuli unwrap into a triangular prism so A = 1/2(2πr)r becomes spatial, not memorized.</td>
 <td><b>Rhombicosidodecahedron</b><br />A vivid Archimedean solid: blue vertices, warm struts, and 3D symmetry as spectacle.</td>
 <td><b>Cosmic gravity 3D</b><br />Spacetime curvature framed like a science documentary: purple geometry, stars, and field-equation energy.</td>
-<td><b>Derivatives as slopes</b><br />The calculus aha moment: a secant tightens into a tangent so slope becomes visible, not merely symbolic.</td>
 </tr>
 <tr>
+<td><img src="assets/derivatives-as-slopes.gif" alt="Derivatives as slopes" /></td>
 <td><img src="assets/lorenz-attractor.gif" alt="Lorenz attractor" /></td>
 <td><img src="assets/hopf-fibration.gif" alt="Hopf fibration" /></td>
-<td><img src="assets/prolip-scene.gif" alt="ProLIP scene" /></td>
 </tr>
 <tr>
+<td><b>Derivatives as slopes</b><br />The calculus aha moment: a secant tightens into a tangent so slope becomes visible, not merely symbolic.</td>
 <td><b>Lorenz attractor</b><br />Chaos theory with glowing trajectories: sensitive dependence becomes a butterfly-shaped object.</td>
 <td><b>Hopf fibration</b><br />Topology as choreography: nested colored fibers give stereographic projection a spatial rhythm.</td>
-<td><b>ProLIP scene</b><br />Scientific network storytelling with molecular/protein graph motifs and highlighted interactions.</td>
+</tr>
+<tr>
+<td colspan="3"><img src="assets/prolip-scene.gif" alt="ProLIP scene" /></td>
+</tr>
+<tr>
+<td colspan="3"><b>ProLIP scene</b><br />Scientific network storytelling with molecular/protein graph motifs and highlighted interactions.</td>
 </tr>
 </table>
 
@@ -105,6 +111,7 @@ They are not just decoration. They define the bar M2M2 should eventually hit:
 | File | Theme | Description |
 | --- | --- | --- |
 | `assets/brownian-finance.gif` | Probability / finance | Calculus accumulation gives way to measure-theoretic uncertainty and sample-space intuition. |
+| `assets/circle-area-3d-unwrapped.gif` | Geometry / calculus | X-video-inspired M2M2 render: nested circle annuli unwrap into a 3D triangular wedge proving A = 1/2(2πr)r = πr². |
 | `assets/continuous-geometric-picture.gif` | ML / reinforcement learning | Full-length GRPO response-manifold recovery render: a 39-second geometric policy-update arc. |
 | `assets/cosmic-gravity-3d.gif` | Physics | A cinematic spacetime-curvature scene with cosmic scale and documentary pacing. |
 | `assets/derivative-visualization.gif` | Calculus | Foundational curve, axes, and local-linearization setup. |


### PR DESCRIPTION
## Summary
- Adds the new 3D circle-area annulus-to-wedge GIF to docs/showcase/assets
- Adds it to the homepage README GIF gallery
- Adds it to the showcase featured reel and asset inventory

## Verification
- ffprobe validated GIF metadata: 760x427, 10 fps, 270 frames, 27s, 7.4 MB
- visually inspected generated GIF contact sheet
- git diff --check passed for README.md and docs/showcase/README.md
- remote branch SHA verified against local HEAD
- raw GitHub README and GIF asset verified on the pushed branch