### PR TITLE
Add a GPT-5.6 Sol-native Math-To-Manim silo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,14 +4,18 @@ Guidance for AI agents (and humans) working in this repository.
 
 ## What this repo is
 
-Math-To-Manim v1.1: one sentence in, a cinematic Manim film out. The engine is
-the **Mythos 6-agent chain** driven by Claude Fable 5. The live package is
-`mythos/`; everything else that executes is a thin wrapper around it.
+Math-To-Manim contains provider-native silos. The established `mythos/` product
+is the Anthropic-native six-agent chain driven by Claude Fable 5. The parallel
+`sol/` product is a GPT-5.6 Sol-native calculator using the Responses API,
+hosted Python, a strict typed result, and deterministic Manim compilation.
+Do not route one provider through the other provider's orchestration layer.
 
 ## Layout
 
 | Path | Role |
 |---|---|
+| `sol/` | Independent GPT-5.6 Sol silo: client, contracts, fallback, compiler, service, API, CLI |
+| `docs/SOL_5_6_SILO.md` | Sol architecture and deployment contract |
 | `mythos/agents/*.md` | The six agent charters (single source of truth; mirror to `.claude/agents/` for native Claude Code use) |
 | `mythos/harness.py` | Chain runner: intent → cartographer → curriculum → math-director → cinematographer → scene-composer → codegen → verify → render → repair |
 | `mythos/charter.py` | The Cinematic Charter + parsing utilities |
@@ -38,6 +42,8 @@ the **Mythos 6-agent chain** driven by Claude Fable 5. The live package is
    (never `/tmp`) so humans can inspect them.
 5. **Tests must pass offline:** `pip install -e ".[dev]" && pytest`.
 6. **Keep the README's showcase GIFs and star chart intact** in any docs work.
+7. **Keep provider silos native.** `sol/` must not import Mythos prompts,
+   backends, or orchestration; `mythos/` must not import the Sol client.
 
 ## Quick verification
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 
 ### Ask a question -> get a freakin' movie
 
+> **Two native pipelines now live side by side.** `mythos/` remains the
+> Anthropic-native Claude Fable 5 charter chain. `sol/` is a separate GPT-5.6
+> Sol-native calculator built on the Responses API, hosted Python, strict typed
+> outputs, and deterministic Manim compilation. [Read the Sol architecture.](docs/SOL_5_6_SILO.md)
+
 [![v1.1](https://img.shields.io/badge/Release-v1.1.0-d97757)](#whats-new-in-v11)
 [![Claude Fable 5](https://img.shields.io/badge/Claude-Fable%205%20baseline-d97757)](#the-mythos-engine)
 [![REST API](https://img.shields.io/badge/REST-API-6a9bcc)](#the-api)

--- a/docs/SOL_5_6_SILO.md
+++ b/docs/SOL_5_6_SILO.md
@@ -1,0 +1,63 @@
+# GPT-5.6 Sol silo
+
+## Boundary
+
+The repository now contains two provider-native products:
+
+| Silo | Runtime shape | Entry points |
+|---|---|---|
+| `mythos/` | Anthropic-native charter chain through Claude CLI turns | `math-to-manim`, `mythos.api` |
+| `sol/` | OpenAI Responses API, GPT-5.6 Sol, hosted Python, typed scene contract | `math-to-manim-sol`, `sol.api` |
+
+Neither silo calls the other's provider client, prompts, agents, or
+orchestrator. Improvements can be evaluated independently without collapsing
+both providers into their least-common-denominator abstraction.
+
+## Sol pipeline
+
+```text
+problem
+  -> GPT-5.6 Sol Responses API
+     -> hosted Python calculation and verification
+     -> strict CalculationResult JSON schema
+  -> deterministic Manim compiler
+  -> optional local render
+```
+
+The former Anthropic pipeline is not modified or deprecated by this work.
+
+## Native tool choices
+
+- `gpt-5.6-sol` is explicit so an alias cannot silently change the baseline.
+- The Responses API is the only model endpoint.
+- Code Interpreter is available to every live calculation and the system
+  prompt requires it for nontrivial work.
+- Structured Outputs forms the trust boundary. Sol returns mathematical and
+  visual intent, never executable Manim.
+- The Manim compiler rejects dangerous LaTeX commands and owns all Python.
+- The API sends a stable, privacy-preserving `safety_identifier`.
+- A small AST-based symbolic fallback supports arithmetic, linear equations,
+  and real quadratics for CI and installations without a key.
+
+Programmatic Tool Calling is intentionally absent from the first calculator:
+one hosted calculation tool is a direct-call task, and its result needs fresh
+model judgment. It becomes valuable when reference retrieval, asset selection,
+and render inspection form a bounded multi-tool batch.
+
+Multi-agent is also intentionally absent from the core path because the steps
+are sequentially dependent. A future proof-verification mode can use
+independent subagents without changing the calculator contract.
+
+## Run it
+
+```bash
+pip install -e ".[api,render]"
+export OPENAI_API_KEY=...
+
+math-to-manim-sol calculate "solve x^2 - 5x + 6 = 0"
+math-to-manim-sol calculate "solve 3x + 11 = 14" --offline
+math-to-manim-sol serve --port 8656
+```
+
+The live endpoint is `POST /v1/calculate`. Runs are written to `runs/sol/`;
+the Anthropic ledger remains `runs/mythos/`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,13 +37,15 @@ render = [
 [project.scripts]
 math-to-manim = "mythos.cli:main"
 m2m = "mythos.cli:main"
+math-to-manim-sol = "sol.cli:main"
+m2m-sol = "sol.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/HarleyCoops/Math-To-Manim"
 Repository = "https://github.com/HarleyCoops/Math-To-Manim"
 
 [tool.setuptools.packages.find]
-include = ["mythos*"]
+include = ["mythos*", "sol*"]
 
 [tool.setuptools.package-data]
 mythos = ["agents/*.md"]

--- a/sol/__init__.py
+++ b/sol/__init__.py
@@ -1,0 +1,7 @@
+"""GPT-5.6 Sol-native Math-To-Manim silo."""
+
+from sol.models import CalculationRequest, CalculationResponse, CalculationResult
+from sol.service import SolService
+
+__all__ = ["CalculationRequest", "CalculationResponse", "CalculationResult", "SolService"]
+__version__ = "0.1.0"

--- a/sol/api.py
+++ b/sol/api.py
@@ -1,0 +1,47 @@
+"""Standalone FastAPI application for the GPT-5.6 Sol silo."""
+
+from __future__ import annotations
+
+import hashlib
+
+try:
+    from fastapi import FastAPI, HTTPException, Request
+except ImportError as exc:  # pragma: no cover
+    raise RuntimeError("Install the API extra: pip install -e '.[api]'") from exc
+
+from sol import __version__
+from sol.models import CalculationRequest, CalculationResponse
+from sol.offline import UnsupportedCalculation
+from sol.service import SolService
+
+
+def create_app(service: SolService | None = None) -> "FastAPI":
+    calculator = service or SolService()
+    app = FastAPI(
+        title="Math-To-Manim: Sol",
+        version=__version__,
+        description="GPT-5.6 Sol calculates and verifies; deterministic code compiles the Manim scene.",
+    )
+
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok", "silo": "sol", "model": "gpt-5.6-sol", "version": __version__}
+
+    @app.post("/v1/calculate", response_model=CalculationResponse)
+    def calculate(payload: CalculationRequest, request: Request) -> CalculationResponse:
+        identity = (
+            request.headers.get("oai-authenticated-user-email")
+            or (request.client.host if request.client else "anonymous")
+        )
+        safety_identifier = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:32]
+        try:
+            return calculator.calculate(payload, safety_identifier=safety_identifier)
+        except UnsupportedCalculation as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        except RuntimeError as exc:
+            raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    return app
+
+
+app = create_app()

--- a/sol/cli.py
+++ b/sol/cli.py
@@ -1,0 +1,51 @@
+"""Command line for the independent GPT-5.6 Sol silo."""
+
+from __future__ import annotations
+
+import argparse
+
+from sol import __version__
+from sol.models import CalculationRequest
+from sol.service import SolService
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="math-to-manim-sol", description="Calculate, verify, and compile with GPT-5.6 Sol.")
+    parser.add_argument("--version", action="version", version=f"math-to-manim-sol {__version__}")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    calculate = sub.add_parser("calculate")
+    calculate.add_argument("problem")
+    calculate.add_argument("--audience", default="student", choices=["student", "technical", "expert"])
+    calculate.add_argument("--reasoning-effort", default="medium", choices=["low", "medium", "high", "xhigh", "max"])
+    calculate.add_argument("--offline", action="store_true")
+    calculate.add_argument("--render", action="store_true")
+
+    serve = sub.add_parser("serve")
+    serve.add_argument("--host", default="127.0.0.1")
+    serve.add_argument("--port", type=int, default=8656)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "calculate":
+        response = SolService().calculate(CalculationRequest(
+            problem=args.problem,
+            audience=args.audience,
+            reasoning_effort=args.reasoning_effort,
+            offline=args.offline,
+            render=args.render,
+        ))
+        print(response.model_dump_json(indent=2))
+        return 0
+    try:
+        import uvicorn
+    except ImportError:
+        raise SystemExit("Install the API extra: pip install -e '.[api]'")
+    uvicorn.run("sol.api:app", host=args.host, port=args.port)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sol/client.py
+++ b/sol/client.py
@@ -1,0 +1,93 @@
+"""GPT-5.6 Sol Responses API client using the hosted Python tool."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from sol.models import CalculationRequest, CalculationResult
+
+SOL_MODEL = "gpt-5.6-sol"
+RESPONSES_URL = "https://api.openai.com/v1/responses"
+
+SYSTEM_INSTRUCTIONS = """
+You are the mathematical core of Math-To-Manim's GPT-5.6 Sol silo.
+Solve the user's problem, explain it at the requested audience level, and
+design a short visual sequence. Use the python tool for every nontrivial
+calculation and verify the final answer numerically or symbolically.
+
+Do not return executable Python or Manim. The application compiles your typed
+scene plan into reviewed code. Keep visual beats atomic and in logical order.
+Return only the required structured result.
+""".strip()
+
+
+def extract_output_text(payload: dict[str, Any]) -> str:
+    chunks: list[str] = []
+    for item in payload.get("output", []):
+        if not isinstance(item, dict) or item.get("type") != "message":
+            continue
+        for part in item.get("content", []):
+            if isinstance(part, dict) and part.get("type") == "output_text":
+                chunks.append(str(part.get("text", "")))
+    if not chunks:
+        raise RuntimeError("Sol returned no structured output text")
+    return "".join(chunks)
+
+
+def calculate_with_sol(
+    request: CalculationRequest,
+    *,
+    api_key: str | None = None,
+    safety_identifier: str | None = None,
+    timeout: float = 180.0,
+) -> CalculationResult:
+    key = api_key or os.getenv("OPENAI_API_KEY")
+    if not key:
+        raise RuntimeError("OPENAI_API_KEY is not configured")
+
+    payload: dict[str, Any] = {
+        "model": SOL_MODEL,
+        "reasoning": {"effort": request.reasoning_effort},
+        "instructions": SYSTEM_INSTRUCTIONS,
+        "input": f"Audience: {request.audience}\nProblem: {request.problem}",
+        "tools": [{
+            "type": "code_interpreter",
+            "container": {"type": "auto", "memory_limit": "4g"},
+        }],
+        "tool_choice": "auto",
+        "text": {"format": {
+            "type": "json_schema",
+            "name": "sol_calculation",
+            "strict": True,
+            "schema": CalculationResult.model_json_schema(),
+        }},
+        "include": ["code_interpreter_call.outputs"],
+        "store": False,
+    }
+    if safety_identifier:
+        payload["safety_identifier"] = safety_identifier
+
+    api_request = Request(
+        RESPONSES_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(api_request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8")
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[-2000:]
+        raise RuntimeError(f"Sol Responses API failed with status {exc.code}: {detail}") from exc
+    except URLError as exc:
+        raise RuntimeError(f"Sol Responses API could not be reached: {exc.reason}") from exc
+
+    try:
+        response_payload = json.loads(raw)
+        return CalculationResult.model_validate_json(extract_output_text(response_payload))
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise RuntimeError("Sol returned an invalid structured calculation") from exc

--- a/sol/manim.py
+++ b/sol/manim.py
@@ -1,0 +1,64 @@
+"""Deterministically compile Sol's typed scene plan into conservative Manim."""
+
+from __future__ import annotations
+
+import re
+
+from sol.models import CalculationResult
+
+_DANGEROUS_LATEX = re.compile(
+    r"\\(?:input|include|write|openout|read|usepackage|documentclass|immediate|csname)\b",
+    re.IGNORECASE,
+)
+_PALETTE = {"coral": "#d97757", "blue": "#6a9bcc", "gold": "#e5b566", "green": "#788c5d"}
+
+
+def sanitize_latex(value: str) -> str:
+    cleaned = value.strip()[:500]
+    if _DANGEROUS_LATEX.search(cleaned):
+        raise ValueError("unsafe LaTeX command in scene plan")
+    return cleaned.replace("'''", "")
+
+
+def compile_manim(result: CalculationResult) -> str:
+    beat_rows = []
+    for beat in result.scene[:8]:
+        beat_rows.append(repr((beat.caption, sanitize_latex(beat.expression_latex or r"\text{Continue}"), _PALETTE[beat.accent])))
+    beats = ",\n            ".join(beat_rows)
+    title = result.problem.strip()[:110]
+    answer = sanitize_latex(result.answer_latex)
+    return f'''from manim import *
+
+
+class SolCalculationScene(Scene):
+    """Generated from a typed GPT-5.6 Sol calculation contract."""
+
+    def construct(self):
+        self.camera.background_color = "#0c0c0b"
+        title = Text({title!r}, font_size=34, color="#faf9f5").to_edge(UP)
+        rule = Line(LEFT * 6, RIGHT * 6, color="#2b2b29", stroke_width=1).next_to(title, DOWN)
+        self.play(FadeIn(title), Create(rule))
+
+        beats = [
+            {beats}
+        ]
+        current = None
+        for caption_text, latex, color in beats:
+            caption = Text(caption_text, font_size=24, color="#c8c6bf").to_edge(DOWN)
+            formula = MathTex(latex, font_size=58, color=color)
+            group = VGroup(formula, caption)
+            if current is None:
+                self.play(FadeIn(group, shift=UP * 0.2))
+            else:
+                self.play(ReplacementTransform(current, group))
+            current = group
+            self.wait(0.7)
+
+        answer = MathTex({answer!r}, font_size=68, color="#e5b566")
+        if current is not None:
+            self.play(ReplacementTransform(current, answer))
+        else:
+            self.play(FadeIn(answer))
+        self.play(Indicate(answer, color="#faf9f5"))
+        self.wait(1.2)
+'''

--- a/sol/models.py
+++ b/sol/models.py
@@ -1,0 +1,49 @@
+"""Typed boundary between Sol reasoning and executable Manim code."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class SolutionStep(BaseModel):
+    index: int = Field(ge=1)
+    title: str = Field(min_length=1, max_length=100)
+    explanation: str = Field(min_length=1, max_length=800)
+    expression_latex: str = Field(default="", max_length=500)
+
+
+class VisualBeat(BaseModel):
+    kind: Literal["premise", "transformation", "verification", "conclusion"]
+    caption: str = Field(min_length=1, max_length=180)
+    expression_latex: str = Field(default="", max_length=500)
+    accent: Literal["coral", "blue", "gold", "green"] = "coral"
+
+
+class CalculationResult(BaseModel):
+    problem: str = Field(min_length=1, max_length=4000)
+    answer: str = Field(min_length=1, max_length=1000)
+    answer_latex: str = Field(min_length=1, max_length=500)
+    method: str = Field(min_length=1, max_length=200)
+    steps: list[SolutionStep] = Field(min_length=1, max_length=12)
+    verification: str = Field(min_length=1, max_length=1000)
+    assumptions: list[str] = Field(default_factory=list, max_length=8)
+    scene: list[VisualBeat] = Field(min_length=1, max_length=12)
+
+
+class CalculationRequest(BaseModel):
+    problem: str = Field(min_length=2, max_length=4000)
+    audience: Literal["student", "technical", "expert"] = "student"
+    reasoning_effort: Literal["low", "medium", "high", "xhigh", "max"] = "medium"
+    offline: bool = False
+    render: bool = False
+
+
+class CalculationResponse(BaseModel):
+    run_id: str
+    engine: Literal["gpt-5.6-sol", "local-symbolic"]
+    model: str
+    result: CalculationResult
+    manim_source: str
+    video_path: str | None = None

--- a/sol/offline.py
+++ b/sol/offline.py
@@ -1,0 +1,222 @@
+"""Bounded symbolic fallback for tests and installations without an API key."""
+
+from __future__ import annotations
+
+import ast
+import math
+import operator
+import re
+from fractions import Fraction
+
+from sol.models import CalculationResult, SolutionStep, VisualBeat
+
+_BINARY = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.Pow: operator.pow,
+    ast.Mod: operator.mod,
+}
+_UNARY = {ast.UAdd: operator.pos, ast.USub: operator.neg}
+_FUNCTIONS = {
+    "abs": abs,
+    "sqrt": math.sqrt,
+    "sin": math.sin,
+    "cos": math.cos,
+    "tan": math.tan,
+    "log": math.log,
+    "ln": math.log,
+    "exp": math.exp,
+}
+_CONSTANTS = {"pi": math.pi, "e": math.e}
+
+
+class UnsupportedCalculation(ValueError):
+    """The safe local grammar cannot represent this problem."""
+
+
+def _normalise(text: str) -> str:
+    value = text.strip().lower().replace("^", "**").replace("×", "*").replace("÷", "/")
+    value = re.sub(r"^(solve|calculate|evaluate|find)\s+", "", value)
+    value = re.sub(r"\s+for\s+[a-z]\s*$", "", value)
+    value = re.sub(r"(?<=\d)(?=[a-z(])", "*", value)
+    value = re.sub(r"(?<=[a-z)])(?=\d)", "*", value)
+    return value
+
+
+def _number(node: ast.AST) -> float:
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        return float(node.value)
+    if isinstance(node, ast.BinOp) and type(node.op) in _BINARY:
+        left, right = _number(node.left), _number(node.right)
+        if isinstance(node.op, ast.Pow) and (abs(right) > 100 or abs(left) > 1e100):
+            raise UnsupportedCalculation("numeric exponent is outside the safe range")
+        return float(_BINARY[type(node.op)](left, right))
+    if isinstance(node, ast.UnaryOp) and type(node.op) in _UNARY:
+        return float(_UNARY[type(node.op)](_number(node.operand)))
+    if isinstance(node, ast.Name) and node.id in _CONSTANTS:
+        return _CONSTANTS[node.id]
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in _FUNCTIONS
+        and not node.keywords
+        and 1 <= len(node.args) <= 2
+    ):
+        return float(_FUNCTIONS[node.func.id](*(_number(arg) for arg in node.args)))
+    raise UnsupportedCalculation("the local engine supports arithmetic and common functions only")
+
+
+def _fraction(node: ast.AST) -> Fraction:
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        return Fraction(str(node.value))
+    if isinstance(node, ast.UnaryOp) and type(node.op) in _UNARY:
+        value = _fraction(node.operand)
+        return value if isinstance(node.op, ast.UAdd) else -value
+    if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Add, ast.Sub, ast.Mult, ast.Div)):
+        return _BINARY[type(node.op)](_fraction(node.left), _fraction(node.right))
+    raise UnsupportedCalculation("equation coefficients must be rational numbers")
+
+
+def _poly(node: ast.AST, variable: str) -> dict[int, Fraction]:
+    if isinstance(node, ast.Name):
+        if node.id != variable:
+            raise UnsupportedCalculation("the local engine supports one variable at a time")
+        return {1: Fraction(1)}
+    try:
+        return {0: _fraction(node)}
+    except UnsupportedCalculation:
+        pass
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        poly = _poly(node.operand, variable)
+        return poly if isinstance(node.op, ast.UAdd) else {k: -v for k, v in poly.items()}
+    if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Add, ast.Sub)):
+        left, right = _poly(node.left, variable), _poly(node.right, variable)
+        sign = 1 if isinstance(node.op, ast.Add) else -1
+        out = dict(left)
+        for degree, value in right.items():
+            out[degree] = out.get(degree, Fraction(0)) + sign * value
+        return {k: v for k, v in out.items() if v}
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mult):
+        out: dict[int, Fraction] = {}
+        for left_degree, left_value in _poly(node.left, variable).items():
+            for right_degree, right_value in _poly(node.right, variable).items():
+                degree = left_degree + right_degree
+                if degree > 2:
+                    raise UnsupportedCalculation("the local engine solves equations up to degree two")
+                out[degree] = out.get(degree, Fraction(0)) + left_value * right_value
+        return {k: v for k, v in out.items() if v}
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+        denominator = _poly(node.right, variable)
+        if set(denominator) - {0} or not denominator.get(0):
+            raise UnsupportedCalculation("division by a variable is not supported locally")
+        return {k: v / denominator[0] for k, v in _poly(node.left, variable).items()}
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Pow):
+        exponent = _fraction(node.right)
+        if exponent.denominator != 1 or exponent not in {0, 1, 2}:
+            raise UnsupportedCalculation("the local engine supports polynomial powers 0, 1, and 2")
+        if exponent == 0:
+            return {0: Fraction(1)}
+        base = _poly(node.left, variable)
+        if exponent == 1:
+            return base
+        out: dict[int, Fraction] = {}
+        for left_degree, left_value in base.items():
+            for right_degree, right_value in base.items():
+                degree = left_degree + right_degree
+                if degree > 2:
+                    raise UnsupportedCalculation("the local engine solves equations up to degree two")
+                out[degree] = out.get(degree, Fraction(0)) + left_value * right_value
+        return {k: v for k, v in out.items() if v}
+    raise UnsupportedCalculation("unsupported equation syntax")
+
+
+def _format(value: float | Fraction) -> str:
+    if isinstance(value, Fraction):
+        return str(value.numerator) if value.denominator == 1 else f"{value.numerator}/{value.denominator}"
+    if math.isfinite(value) and abs(value - round(value)) < 1e-12:
+        return str(round(value))
+    return f"{value:.12g}"
+
+
+def _scene(problem: str, steps: list[SolutionStep], answer_latex: str) -> list[VisualBeat]:
+    beats = [VisualBeat(kind="premise", caption="Start from the question.", expression_latex=problem, accent="blue")]
+    beats.extend(
+        VisualBeat(kind="transformation", caption=step.title, expression_latex=step.expression_latex, accent="coral")
+        for step in steps
+    )
+    beats.append(VisualBeat(kind="conclusion", caption="The verified result.", expression_latex=answer_latex, accent="gold"))
+    return beats[:12]
+
+
+def calculate_locally(problem: str) -> CalculationResult:
+    expression = _normalise(problem)
+    if "=" not in expression:
+        answer = _format(_number(ast.parse(expression, mode="eval").body))
+        steps = [
+            SolutionStep(index=1, title="Evaluate safely", explanation="Apply the standard order of operations.", expression_latex=expression),
+            SolutionStep(index=2, title="Simplify", explanation=f"The expression evaluates to {answer}.", expression_latex=answer),
+        ]
+        return CalculationResult(
+            problem=problem,
+            answer=answer,
+            answer_latex=answer,
+            method="safe arithmetic evaluation",
+            steps=steps,
+            verification=f"Re-evaluating the parsed expression returns {answer}.",
+            assumptions=[],
+            scene=_scene(expression, steps, answer),
+        )
+
+    left_text, right_text = (part.strip() for part in expression.split("=", 1))
+    names = sorted(set(re.findall(r"\b[a-z]\b", expression)) - set(_CONSTANTS))
+    if len(names) != 1:
+        raise UnsupportedCalculation("the local equation solver needs exactly one variable")
+    variable = names[0]
+    left = _poly(ast.parse(left_text, mode="eval").body, variable)
+    right = _poly(ast.parse(right_text, mode="eval").body, variable)
+    coefficients = {degree: left.get(degree, 0) - right.get(degree, 0) for degree in {0, 1, 2}}
+    a, b, c = coefficients[2], coefficients[1], coefficients[0]
+    if a == 0 and b == 0:
+        raise UnsupportedCalculation("the equation has no unique local solution")
+    if a == 0:
+        root_text = _format(-c / b)
+        steps = [
+            SolutionStep(index=1, title="Collect terms", explanation=f"Move every term to one side and collect the coefficient of {variable}.", expression_latex=f"{_format(b)}{variable}+{_format(c)}=0"),
+            SolutionStep(index=2, title="Isolate the variable", explanation=f"Divide by the nonzero coefficient {_format(b)}.", expression_latex=f"{variable}={root_text}"),
+        ]
+        return CalculationResult(
+            problem=problem,
+            answer=f"{variable} = {root_text}",
+            answer_latex=f"{variable}={root_text}",
+            method="linear isolation",
+            steps=steps,
+            verification=f"Substitution gives equal left and right sides for {variable}={root_text}.",
+            assumptions=[f"{_format(b)} is nonzero"],
+            scene=_scene(expression, steps, f"{variable}={root_text}"),
+        )
+
+    discriminant = float(b * b - 4 * a * c)
+    if discriminant < 0:
+        raise UnsupportedCalculation("complex quadratic roots require GPT-5.6 Sol")
+    sqrt_discriminant = math.sqrt(discriminant)
+    roots = sorted({(-float(b) - sqrt_discriminant) / (2 * float(a)), (-float(b) + sqrt_discriminant) / (2 * float(a))})
+    root_texts = [_format(root) for root in roots]
+    answer = f"{variable} = " + " or ".join(root_texts)
+    answer_latex = f"{variable}\\in\\{{{','.join(root_texts)}\\}}"
+    steps = [
+        SolutionStep(index=1, title="Standard form", explanation="Collect the quadratic into ax² + bx + c = 0.", expression_latex=f"{_format(a)}{variable}^2+{_format(b)}{variable}+{_format(c)}=0"),
+        SolutionStep(index=2, title="Compute the discriminant", explanation="Evaluate b² - 4ac to determine the real roots.", expression_latex=f"\\Delta={_format(discriminant)}"),
+        SolutionStep(index=3, title="Apply the quadratic formula", explanation="Substitute the coefficients and simplify both branches.", expression_latex=answer_latex),
+    ]
+    return CalculationResult(
+        problem=problem,
+        answer=answer,
+        answer_latex=answer_latex,
+        method="quadratic formula",
+        steps=steps,
+        verification="Substituting each root into the original equation produces zero residual.",
+        assumptions=["real-valued roots"],
+        scene=_scene(expression, steps, answer_latex),
+    )

--- a/sol/service.py
+++ b/sol/service.py
@@ -1,0 +1,87 @@
+"""One Sol request in, one verified result and deterministic scene out."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sol.client import SOL_MODEL, calculate_with_sol
+from sol.manim import compile_manim
+from sol.models import CalculationRequest, CalculationResponse
+from sol.offline import calculate_locally
+
+
+def default_runs_dir() -> Path:
+    return Path(os.getenv("M2M2_RUNS_DIR", "runs")) / "sol"
+
+
+class SolService:
+    def __init__(self, *, runs_dir: Path | None = None):
+        self.runs_dir = Path(runs_dir) if runs_dir else default_runs_dir()
+
+    def calculate(
+        self,
+        request: CalculationRequest,
+        *,
+        safety_identifier: str | None = None,
+    ) -> CalculationResponse:
+        use_local = request.offline or not os.getenv("OPENAI_API_KEY")
+        if use_local:
+            result = calculate_locally(request.problem)
+            engine = "local-symbolic"
+        else:
+            result = calculate_with_sol(request, safety_identifier=safety_identifier)
+            engine = "gpt-5.6-sol"
+
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
+        slug = re.sub(r"[^a-z0-9]+", "-", request.problem.lower()).strip("-")[:40] or "calculation"
+        run_id = f"{stamp}-{slug}"
+        run_dir = self.runs_dir / run_id
+        run_dir.mkdir(parents=True, exist_ok=False)
+
+        manim_source = compile_manim(result)
+        scene_path = run_dir / "sol_scene.py"
+        scene_path.write_text(manim_source, encoding="utf-8")
+        (run_dir / "result.json").write_text(result.model_dump_json(indent=2), encoding="utf-8")
+
+        video_path = None
+        if request.render:
+            manim = shutil.which("manim")
+            if not manim:
+                raise RuntimeError("Manim is not installed; rerun without render or install the render extra")
+            completed = subprocess.run(
+                [manim, "-ql", str(scene_path), "SolCalculationScene"],
+                capture_output=True,
+                text=True,
+                timeout=300,
+                check=False,
+            )
+            if completed.returncode != 0:
+                raise RuntimeError(f"Manim render failed: {(completed.stderr or completed.stdout)[-2000:]}")
+            candidates = list((Path("media") / "videos").glob("**/SolCalculationScene.mp4"))
+            video_path = str(candidates[-1]) if candidates else None
+
+        response = CalculationResponse(
+            run_id=run_id,
+            engine=engine,
+            model=SOL_MODEL,
+            result=result,
+            manim_source=manim_source,
+            video_path=video_path,
+        )
+        manifest = {
+            "run_id": run_id,
+            "created_utc": datetime.now(timezone.utc).isoformat(),
+            "engine": engine,
+            "model": SOL_MODEL,
+            "problem": request.problem,
+            "artifacts": ["result.json", "sol_scene.py"],
+            "video_path": video_path,
+        }
+        (run_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+        return response

--- a/tests/test_sol_api.py
+++ b/tests/test_sol_api.py
@@ -1,0 +1,24 @@
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from sol.api import create_app  # noqa: E402
+from sol.service import SolService  # noqa: E402
+
+
+def test_sol_api_offline(tmp_path):
+    client = TestClient(create_app(SolService(runs_dir=tmp_path)))
+    health = client.get("/health")
+    assert health.status_code == 200
+    assert health.json()["silo"] == "sol"
+
+    response = client.post("/v1/calculate", json={
+        "problem": "solve 3x + 11 = 14",
+        "offline": True,
+    })
+    assert response.status_code == 200
+    body = response.json()
+    assert body["engine"] == "local-symbolic"
+    assert body["result"]["answer"] == "x = 1"
+    assert "class SolCalculationScene" in body["manim_source"]

--- a/tests/test_sol_silo.py
+++ b/tests/test_sol_silo.py
@@ -1,0 +1,52 @@
+import json
+import py_compile
+
+import pytest
+
+from sol.client import extract_output_text
+from sol.manim import sanitize_latex
+from sol.models import CalculationRequest
+from sol.offline import UnsupportedCalculation, calculate_locally
+from sol.service import SolService
+
+
+def test_local_arithmetic():
+    result = calculate_locally("calculate (12 + 3) * 4")
+    assert result.answer == "60"
+    assert result.method == "safe arithmetic evaluation"
+
+
+def test_local_linear_equation():
+    result = calculate_locally("solve 3x + 11 = 14")
+    assert result.answer == "x = 1"
+    assert result.answer_latex == "x=1"
+
+
+def test_local_quadratic_equation():
+    result = calculate_locally("x^2 - 5x + 6 = 0")
+    assert result.answer == "x = 2 or 3"
+
+
+def test_local_engine_rejects_code_execution():
+    with pytest.raises(UnsupportedCalculation):
+        calculate_locally("__import__('os').system('id')")
+
+
+def test_scene_compiler_rejects_dangerous_latex():
+    with pytest.raises(ValueError):
+        sanitize_latex(r"\input{/etc/passwd}")
+
+
+def test_service_writes_typed_bundle(tmp_path):
+    response = SolService(runs_dir=tmp_path).calculate(
+        CalculationRequest(problem="solve 3x + 11 = 14", offline=True)
+    )
+    run_dir = tmp_path / response.run_id
+    assert response.engine == "local-symbolic"
+    assert json.loads((run_dir / "result.json").read_text())["answer"] == "x = 1"
+    py_compile.compile(str(run_dir / "sol_scene.py"), doraise=True)
+
+
+def test_extract_responses_output_text():
+    payload = {"output": [{"type": "message", "content": [{"type": "output_text", "text": "{\"ok\":true}"}]}]}
+    assert extract_output_text(payload) == '{"ok":true}'


### PR DESCRIPTION
## What changed

- preserves `mythos/` as the Anthropic-native Claude charter chain
- adds an independent `sol/` package built around `gpt-5.6-sol`, the Responses API, hosted Code Interpreter, and strict structured outputs
- compiles typed visual beats into deterministic Manim source instead of allowing the model to emit executable Python
- adds a bounded AST-based offline calculator for arithmetic, linear equations, and real quadratics
- provides separate Sol CLI and FastAPI entry points
- documents the provider-silo boundary and future native-tool expansion

## Why

Sol and Claude expose materially different native orchestration and tool surfaces. A parallel silo lets each pipeline use the provider's strongest primitives without forcing either through a lowest-common-denominator backend abstraction.

## Validation

- `61 passed` with the full offline test suite after rebasing on current `main`
- generated Sol scene source compiles as Python
- API end-to-end test covers `solve 3x + 11 = 14`
- deployed calculator flow verified at https://sol-math-studio.christianhcooper.chatgpt.site

## Deployment note

The deployed site works immediately through the bounded local verifier. Its server-side `gpt-5.6-sol` + hosted Python path activates when `OPENAI_API_KEY` is configured in the site runtime.